### PR TITLE
fix: Source 'defaultBranch' from instance for getFileContents instead of argument.

### DIFF
--- a/src/github.ts
+++ b/src/github.ts
@@ -643,7 +643,7 @@ export class GitHub {
     }
 
     //  Actually update the files for the release:
-    const changes = await this.getChangeSet(options.updates, defaultBranch);
+    const changes = await this.getChangeSet(options.updates);
     const prNumber = await createPullRequest(
       this.octokit,
       changes,
@@ -688,10 +688,7 @@ export class GitHub {
     }
   }
 
-  private async getChangeSet(
-    updates: Update[],
-    defaultBranch: string
-  ): Promise<Changes> {
+  private async getChangeSet(updates: Update[]): Promise<Changes> {
     const changes = new Map();
     for (const update of updates) {
       let content;
@@ -701,10 +698,7 @@ export class GitHub {
           // hit GitHub again.
           content = {data: update.contents};
         } else {
-          const fileContent = await this.getFileContents(
-            update.path,
-            defaultBranch
-          );
+          const fileContent = await this.getFileContents(update.path);
           content = {data: fileContent};
         }
       } catch (err) {
@@ -824,10 +818,8 @@ export class GitHub {
     };
   }
 
-  async getFileContents(
-    path: string,
-    defaultBranch: string | undefined = undefined
-  ): Promise<GitHubFileContents> {
+  async getFileContents(path: string): Promise<GitHubFileContents> {
+    const defaultBranch = await this.getDefaultBranch(this.owner, this.repo);
     try {
       return await this.getFileContentsWithSimpleAPI(path, defaultBranch);
     } catch (err) {

--- a/test/github.ts
+++ b/test/github.ts
@@ -248,10 +248,7 @@ describe('GitHub', () => {
         )
         .reply(200, dataAPIBlobResponse);
 
-      const fileContents = await github.getFileContents(
-        'package-lock.json',
-        'master'
-      );
+      const fileContents = await github.getFileContents('package-lock.json');
       expect(fileContents).to.have.property('content');
       expect(fileContents).to.have.property('parsedContent');
       expect(fileContents)


### PR DESCRIPTION
Ensures the `github-release` command will source the default branch from the repository (currently not an option passed to the instance)

This seems related to googleapis/release-please#428
